### PR TITLE
Resolve #73

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ tmp.txt
 
 # NV executables
 /nv
+/nv.opt
+/nv.debug
 /nvgen
 
 # Native install files

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.15.0
+version=0.19.0
 profile=janestreet
 space-around-lists=false
 space-around-arrays=false

--- a/src/lib/Main_defs.ml
+++ b/src/lib/Main_defs.ml
@@ -269,16 +269,17 @@ let parse_input (args : string array) =
   let decls = Typing.infer_declarations info decls in
   Typing.check_annot_decls decls;
   Wellformed.check info decls;
-  let partitions, decls =
+  let partitions =
     if cfg.kirigami
     then (
-      let parts = SrpRemapping.partition_declarations decls in
-      let new_symbolics =
-        let aty = get_attr_type decls |> oget in
-        Partition.get_hyp_symbolics aty parts
-      in
-      Some parts, new_symbolics @ decls)
-    else None, decls
+      Some (SrpRemapping.partition_declarations decls))
+      (* let parts = SrpRemapping.partition_declarations decls in
+       * let new_symbolics =
+       *   let aty = get_attr_type decls |> oget in
+       *   Partition.get_hyp_symbolics aty parts
+       * in
+       * Some parts, new_symbolics @ decls) *)
+    else None(* , decls *)
   in
   let decls, f = RecordUnrolling.unroll_declarations decls in
   let fs = [f] in

--- a/src/lib/kirigami/Partition.ml
+++ b/src/lib/kirigami/Partition.ml
@@ -15,43 +15,47 @@ type transform_result =
   | Solution of (partitioned_srp * declaration)
   | None
 
-(** Return a new set of declarations of all symbolics added by partitions. *)
-let get_hyp_symbolics ty partitions =
-  let add_partition_hyps l part =
-    VertexMap.fold
-      (fun _ input_exps l ->
-        List.map (fun ie -> DSymbolic (ie.var, Ty ty)) input_exps @ l)
-      part.inputs
-      l
-  in
-  List.fold_left add_partition_hyps [] partitions
+(** Return a new set of declarations of all symbolics added by this partition. *)
+let get_hyp_symbolics part =
+  VertexMap.fold
+    (fun _ input_exps ds ->
+      List.fold_left
+        (fun ds ie -> List.map (fun (v, t) -> DSymbolic (v, Ty t)) ie.var @ ds)
+        ds
+        input_exps)
+    part.inputs
+    []
 ;;
 
-let valid_hyps parted_srp =
-  let get_vars _ input_exps l =
-    List.map (fun ie -> "symbolic-" ^ Var.name ie.var) input_exps @ l
-  in
-  VertexMap.fold get_vars parted_srp.inputs []
-;;
+(* let valid_hyps parted_srp =
+ *   (\* the "symbolic-" prefix is added by RenameForSMT *\)
+ *   let get_vars _ input_exps l =
+ *     List.map (fun ie -> "symbolic-" ^ Var.name ie.var) input_exps @ l
+ *   in
+ *   VertexMap.fold get_vars parted_srp.inputs []
+ * ;; *)
 
 (** Return a transformed version of the given declaration, and optionally any new Kirigami constraints
- ** that need to be added with it. *)
+ ** that need to be added with it.
+ ** NOTE: must run after Nv_transformations.RenameForSMT.rename_declarations in order to match symbolics
+ ** correctly. *)
 let transform_declaration parted_srp decl : transform_result =
   let ({ nodes; edges; _ } : partitioned_srp) = parted_srp in
-  let valid_hyps = valid_hyps parted_srp in
+  (* let valid_hyps = valid_hyps parted_srp in *)
   match decl with
   | DNodes _ -> Network (DNodes nodes)
-  | DEdges _ -> Network (DEdges edges)
-  (* drop any hypotheses that don't belong to this partition *)
-  | DSymbolic (v, _) ->
+  | DEdges _ ->
+    Network (DEdges edges)
+    (* drop any hypotheses that don't belong to this partition *)
+    (* | DSymbolic (v, _) -> *)
     (* print_endline (Var.name v);
      * print_endline (Nv_utils.OCamlUtils.list_to_string (fun s -> s) valid_hyps); *)
     (* get the original variable form in case it's been projected *)
-    let v = snd (unproj_var v) in
-    if String.starts_with (Var.name v) "symbolic-hyp"
-       && not (List.mem (Var.name v) valid_hyps)
-    then None
-    else Network decl
+    (* let v = snd (unproj_var v) in
+     * if String.starts_with (Var.name v) "symbolic-hyp"
+     *    && not (List.mem (Var.name v) valid_hyps)
+     * then None
+     * else Network decl *)
   | DSolve s ->
     let part', solve' = transform_solve s parted_srp in
     Solution (part', DSolve solve')
@@ -67,5 +71,6 @@ let transform_declarations decls parted_srp =
     | Solution (p, d) -> p, d :: decls
     | None -> part, decls
   in
-  List.fold_left add_new_decl (parted_srp, []) decls
+  let p, ds = List.fold_left add_new_decl (parted_srp, []) decls in
+  p, get_hyp_symbolics p @ ds
 ;;

--- a/src/lib/kirigami/Partition.mli
+++ b/src/lib/kirigami/Partition.mli
@@ -6,8 +6,8 @@ open Nv_lang.Syntax
 open Nv_solution.Solution
 open SrpRemapping
 
-(** Return a new set of declarations of all symbolics added by partitions. *)
-val get_hyp_symbolics : ty -> partitioned_srp list -> declarations
+(* Return a new set of declarations of all symbolics added by partitions. *)
+(* val get_hyp_symbolics : ty -> partitioned_srp list -> declarations *)
 
 (** Given the partitioned SRP, transform the declarations. *)
 val transform_declarations

--- a/src/lib/kirigami/SrpRemapping.ml
+++ b/src/lib/kirigami/SrpRemapping.ml
@@ -11,8 +11,8 @@ open Nv_utils.OCamlUtils
 type input_exp =
   { (* the associated original edge *)
     edge : E.t
-  ; (* the variable associated with the input node *)
-    var : Var.t
+  ; (* the variables associated with the input node *)
+    var : (var * ty) list
   ; (* the partition rank of the associated output *)
     rank : int
   ; (* the associated predicate expressions: functions over attributes *)
@@ -71,8 +71,8 @@ let get_old_nodes parted_srp =
 
 let string_of_input_exp { var; rank; edge; preds } =
   Printf.sprintf
-    "var %s (%d)\n%s: preds %s"
-    (Var.to_string var)
+    "vars %s (%d)\n%s: preds %s"
+    (list_to_string (fun (v,t) -> Printf.sprintf "(%s : %s)" (Var.to_string v) (Printing.ty_to_string t)) var)
     rank
     (Edge.to_string edge)
     (list_to_string Printing.exp_to_string preds)
@@ -204,8 +204,8 @@ let map_edges_to_parts partitions (old_edge, (edge, srp_edge)) =
       then (
         (* construct the record of the new input information: used when creating the
          * symbolic variable and the require predicate *)
-        let hyp_var = Var.fresh (Printf.sprintf "hyp_%s" (Edge.to_string old_edge)) in
-        let input_exp = { edge = old_edge; var = hyp_var; rank = i1; preds = [] } in
+        (* let hyp_var = Var.fresh (Printf.sprintf "hyp_%s" (Edge.to_string old_edge)) in *)
+        let input_exp = { edge = old_edge; var = []; rank = i1; preds = [] } in
         { partition with
           inputs = VertexMap.modify_def [] v (List.cons input_exp) partition.inputs
         })

--- a/src/lib/kirigami/SrpRemapping.mli
+++ b/src/lib/kirigami/SrpRemapping.mli
@@ -7,8 +7,8 @@ open Nv_solution
 type input_exp =
   { (* the associated original edge *)
     edge : E.t
-  ; (* the variable associated with the input node *)
-    var : Var.t
+  ; (* the variables associated with the input node *)
+    var : (var * ty) list
   ; (* the partition rank of the associated output *)
     rank : int
   ; (* the associated predicate expression: a function over attributes *)

--- a/src/lib/smt/SmtUtils.ml
+++ b/src/lib/smt/SmtUtils.ml
@@ -506,7 +506,7 @@ open SmtLang
 module Constant = struct
   type t = constant
 
-  let compare x y = BatString.numeric_compare x.cname y.cname
+  let compare x y = BatString.compare x.cname y.cname
 end
 
 module ConstantSet = BatSet.Make (Constant)


### PR DESCRIPTION
This PR changes `ConstantSet.compare` back to `String.compare` from `String.numeric_compare`, which bumps the speed of encoding back up significantly. To make this change, we have to change how we determine the relevant SMT terms for each input expression: instead of searching through the declared constants, we store the full set of variables for each input. Right now, this is done at partitioning time, which unfortunately means that the type information of the attribute is not used to reconstitute the input `hyp` routes back together.
As a further modification, we should change this to properly use the transformations to map the values back.